### PR TITLE
[hofix] Update `.gitignore` to exclude `.vscode` and fix formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ pyrightconfig.json
 # Custom
 bin/
 tmp/
+.vscode/


### PR DESCRIPTION
- Добавлено исключение для директории .vscode/ во избежание попадания пользовательских настроек IDE в репозиторий
- Исправлено отсутствие перевода строки в конце файла (EOF newline) для соответствия POSIX-стандарту

Изменения предотвращают:
1. Случайный коммит конфигурационных файлов VSCode
2. Предупреждения в инструментах, чувствительных к формату .gitignore

# **Name of PR**

## **Description**

- ***

### **Additional context**

-
